### PR TITLE
missing tokens bug fix

### DIFF
--- a/ngx_http_secure_token_processor_base.c
+++ b/ngx_http_secure_token_processor_base.c
@@ -131,6 +131,7 @@ ngx_http_secure_token_url_state_machine_init(
 	ctx->state = STATE_URL_SCHEME;
 	ctx->scheme_pos = 0;
 	ctx->scheme_delim_pos = 0;
+	ctx->last_url_char = '\0';
 	ctx->tokenize = tokenize;
 	ctx->url_end_state = url_end_state;
 	ctx->url_end_char = url_end_char;


### PR DESCRIPTION
if an input buffers ends on the scheme of the url, last_url_char stays
'\n' from the previous iteration. this makes the m3u8 processor go back
to the initial state. on the next iteration, it will start the url
parsing state machine again, while it's in the middle of the scheme. the
url parser will therefore see only part of the scheme (e.g. tps instead
of https). it will enter the 'non http' state, and skip adding the
token.