### PR TITLE
Add EXT-session-key to signing

### DIFF
--- a/ngx_http_secure_token_m3u8.c
+++ b/ngx_http_secure_token_m3u8.c
@@ -6,6 +6,7 @@ static ngx_str_t uri_tags[] = {
 	ngx_string("EXT-X-KEY"),
 	ngx_string("EXT-X-PART"),
 	ngx_string("EXT-X-MEDIA"),
+	ngx_string("EXT-X-SESSION-KEY"),
 	ngx_string("EXT-X-PRELOAD-HINT"),
 	ngx_string("EXT-X-I-FRAME-STREAM-INF"),
 	ngx_null_string,


### PR DESCRIPTION
When the packager build the master manifest there is optional tag of x-ext-session-key.
This tag contain uri for getting the key for secure playback.
If using secure token token, that uri should be sign as well as the other tags